### PR TITLE
Correcting %e, %i for change in new era

### DIFF
--- a/example-code/app/mars.hoon
+++ b/example-code/app/mars.hoon
@@ -127,10 +127,10 @@
   |=  [=wire =sign-arvo]
   ^-  (quip card _this)
   |^
-  ?:  ?=(%e -.sign-arvo)
+  ?:  ?=(%eyre -.sign-arvo)
     ~&  >>  "Eyre returned: {<+.sign-arvo>}"
     `this
-  ?:  ?=(%i -.sign-arvo)
+  ?:  ?=(%iris -.sign-arvo)
   ?>  ?=(%http-response +<.sign-arvo)
     =^  cards  state
       (handle-response -.wire client-response.sign-arvo)


### PR DESCRIPTION
the references to the vanes have been reverted back (or changed anew?) from %e %i to %eyre %iris, respectively.