### PR TITLE
Added |fade + explanation for first compile

### DIFF
--- a/lifecycle.md
+++ b/lifecycle.md
@@ -1,12 +1,13 @@
 # App Lifecyle and State
 
-Once you register an app with Gall using `|start`, Gall calls specific arms of the app when the app changes. 
+Once you register an app with Gall using `|start`, Gall calls specific arms of the app when the app changes.
 
 In this lesson, you'll see everything about how Gall handles compilation, state, resource initialization, and app upgrades. The main action here will take place in the `on-init`, `on-save`, and `on-load` arms.
 
 We'll also get our sneak peak at calling out to Arvo for networking services.
 
 ## Example Code
+
 We will modify the below code throughout the lesson. Paste it into a file in `app/` called `lifecycle.hoon`.
 
 ```
@@ -40,7 +41,7 @@ We will modify the below code throughout the lesson. Paste it into a file in `ap
 ++  on-save
   ~&  >  'on-save v0'
   !>(state)
-++  on-load 
+++  on-load
   |=  old-state=vase
   ^-  (quip card _this)
   ~&  >  'on-load v0'
@@ -69,23 +70,31 @@ We will modify the below code throughout the lesson. Paste it into a file in `ap
 ```
 
 ## Preamble: `dbug`
-Near the top of the file, you'll see the line `%-  agent:dbug`. This wraps our program in the `dbug` Gall agent, which lets us inspect the state of the program as it's running. Once our agent is started, we can type at the Dojo:
+
+Near the top of the file, you'll see the line `%- agent:dbug`. This wraps our program in the `dbug` Gall agent, which lets us inspect the state of the program as it's running. Once our agent is started, we can type at the Dojo:
+
 ```
 > :lifecycle +dbug
 ```
+
 and we'll see the current state object printed out. We can also do:
+
 ```
 > :lifecycle +dbug %bowl
 ```
+
 and we'll see the `bowl` (Gall metastate for the app) printed. We'll use this later in the lesson.
 
 ## Experiment: 1st Successful Compilation
+
 Before we start, just note that we are using `~&` to print messages in `on-init`, `on-save`, and `on-load`. (You can use up to 3 `>`s with `~&` to print the debug messages in different colors).
 
 We have some bookkeeping code in `on-poke` and `on-arvo` that you can ignore for now.
 
 ### An Unexpected Problem...
+
 Let's register the above application with Gall:
+
 ```
 ::  commit the new code
 > |commit %home
@@ -96,34 +105,60 @@ Let's register the above application with Gall:
 >=
 activated app home/lifecycle
 %path: no matches for /~zod/home/~2020.6.11..15.15.55..b397/lib/default-agen/hoon
-%plan failed: 
+%plan failed:
 ford: %core on /~zod/home/0/app/lifecycle/hoon failed:
 ```
 
 ### Resolution
-What happened? This message is telling us that it can't find something in `lib`: `default-agen/hoon`. This is because we spelled the name wrong. We'll learn about libraries in the [next lesson](ford.md). For now, check the very first line of our program: we need to change it to:
+
+What happened? This message is telling us that it can't find something in `lib`: `default-agen/hoon`. This is because we spelled the name wrong. We'll learn about libraries in the [next lesson](ford.md).
+
+For now, let's continue working on fixing our code. To start we're going to kill our gall application using `|fade`.
+
+```
+|fade  %lifecycle
+```
+
+While this isn't strictly necessary in a perfect world, currently this gets around a bug which breaks gall apps if the first compile fails. This is a command you may find useful when testing/developing gall apps, so this is a good point to introduce it anyways.
+
+Once the lifecycle app is killed we can move onto fixing the spelling mistake on the very first line of our program:
+
 ```
 /+  default-agent, dbug
 ```
-Now commit, and you'll see the following:
+
+Now commit and restart the app again:
+
+```
+|commit %home
+|start %lifecycle
+```
+
+You'll see the following output:
+
 ```
 > |commit %home
 >=
-: /~zod/home/3/app/lifecycle/hoon
+gall: loading %lifecycle
 >   'on-init'
 >>> '%connect Eyre to ~lifecycle'
 >>  'Eyre confirmed the %connect'
+activated app home/lifecycle
 [unlinked from [p=~zod q=%lifecycle]]
 ```
-Notice that `on-init` runs on the first *successful* compilation.
+
+Notice that `on-init` runs on the first _successful_ compilation.
 
 ### Explanation
+
 When Gall registers an app with `|start`, it tries to compile it. If the compilation succeeds, it runs `on-init`. If it fails, it keeps recompiling each time the code is updated with `|commit`. Once compilation succeeds, it runs `on-init`.
 
 After that first time, it never runs `on-init` ever again for that app; it only uses `on-save` and `on-load` after app recompilations, as we will soon see.
 
 ### What Did `on-init` Do?
+
 Let's look at the code of our `on-init` arm:
+
 ```
 ++  on-init
   ^-  (quip card _this)
@@ -134,6 +169,7 @@ Let's look at the code of our `on-init` arm:
       [%pass /bind %arvo %e %connect [~ /'~lifecycle'] %lifecycle]
     ==
 ```
+
 We see that it returns a `(quip card _this)`. As mentioned in the [last lesson](arms.md), this type means a `list` of `card`, along with `_this_` at the end (short for `$_(this)`: the type of `this`, our core).
 
 Gall arms that return this structure are passing 0 or more actions (`card`s) back to Gall to perform, and also return a new state of our app to Gall. You can see more detail on the structure of cards in the [types appendix](appendix_types.md)--this one is an `arvo-note`. It starts with `%pass`, which means it's like a function call. The `%e` is for "Eyre", the Arvo networking vane. This is a command to listen for incoming HTTP requests on address `/~lifecycle` of our ship. We'll explore this more in the [HTTP lesson](http.md).
@@ -141,13 +177,17 @@ Gall arms that return this structure are passing 0 or more actions (`card`s) bac
 Take it as a given for now that this HTTP `card` works. What about our new state?
 
 We use `:_` to put the end of our return tuple first and put the heaviest code at the bottom (the `card`). So `this(state [%0 99])` is the value of our app that we return. Let's use `+dbug to print the state`
+
 ```
 > :lifecycle +dbug
 ```
+
 You should see `[%0 val=99]` as the result. (our `on-save` debug print also prints, since `dbug` calls it).
 
 ### Initializing with 0 or More Cards
+
 If we wanted to initialize with more than one `card`, we would put more elements in the list created with `:~`. If we wanted 0 elements, we could do either of the following, which are equivalent and both put ~ at the front of our tuple:
+
 ```
 ::  Syntax 1
 [~ this(state [%0 99])]
@@ -157,24 +197,27 @@ If we wanted to initialize with more than one `card`, we would put more elements
 ```
 
 ## After the 1st Compilation: State Transitions
-OK, so we know how to initialize our app with 0 or more actions and return an initial state for it.  Let's see what happens when we make changes to the state.
+
+OK, so we know how to initialize our app with 0 or more actions and return an initial state for it. Let's see what happens when we make changes to the state.
 
 ### New Version of State
+
 Make the following changes to your code:
+
 <table>
 <tr>
 <td>::  old </td> <td>::  new</td>
 </tr>
-  
+
 <tr>
 <td>
 
-  ```
-  +$  versioned-state
-    $%  state-0
-  ==
-    
-  ```
+```
++$  versioned-state
+  $%  state-0
+==
+
+```
 
   </td>
 <td>
@@ -301,7 +344,9 @@ Make the following changes to your code:
 </table>
 
 ### State Transition Mechanics
+
 Now commit, and you will see something like this:
+
 ```
 > |commit %home
 >=
@@ -310,34 +355,40 @@ Now commit, and you will see something like this:
 >   'on-load v1'
 >>> '%0'
 ```
+
 And let's also check the current state:
+
 ```
 > :lifecycle +dbug
 [%1 val=100 msg='my message']
 ```
+
 Notice that while our state updated as expected, we can see from the debug prints that Gall called the `"v0"` version of `on-save`, and the `"v1"` version of `on-load`. Why?
 
 Because after each successful compilation, Gall calls:
-* `on-save` of the *prior* version of the app
-* `on-load` of the *new* version of the app
+
+- `on-save` of the _prior_ version of the app
+- `on-load` of the _new_ version of the app
 
 This allows Gall to move the data from a working prior version to our new version.
 
 We also change our `on-init`, so that users installing the app from scratch end up in a consistent state with those who upgrade via `on-load`.
 
 ### Adding an Action after `on-init` Has Already Run
+
 Let's say we want to undo the Eyre binding that we did in `on-init`. How is that possible, given that `on-init` only runs once?
 
 The answer is that `on-load` also returns `(quip card this)`, so we can return cards instead of altering state as part of the transition to a new state.
 
 ### Example: Disconnect Our Eyre Binding
+
 To illustrate this, make the following modifications to the code:
 
 <table>
 <tr>
 <td>::  old </td> <td>::  new</td>
 </tr>
-  
+
 <tr>
 <td>
 
@@ -479,7 +530,7 @@ To illustrate this, make the following modifications to the code:
 %1
 ~&  >>>  '%1'
 :_  this(state [%2 +.prev])
-~[[%pass /bind %arvo %e %disconnect [~ /'~lifecycle']]]    
+~[[%pass /bind %arvo %e %disconnect [~ /'~lifecycle']]]
 ::
 %2
 `this(state prev)
@@ -489,13 +540,14 @@ To illustrate this, make the following modifications to the code:
 </tr>
 </table>
 
-Our new `state-2` is the same as `state-1`--we're just going to add an action in the transition from `%1` to `%2`. 
+Our new `state-2` is the same as `state-1`--we're just going to add an action in the transition from `%1` to `%2`.
 
-The `%1` case now returns a card that disconnects our app from Eyre (no more listening for incoming traffic at a URL), and updates its head to `%2`. We also alter the `%0` case to do *both* the state update and the card update, and bump our version all the way to `%2`, in case a user of our app missed the `%1` update.
+The `%1` case now returns a card that disconnects our app from Eyre (no more listening for incoming traffic at a URL), and updates its head to `%2`. We also alter the `%0` case to do _both_ the state update and the card update, and bump our version all the way to `%2`, in case a user of our app missed the `%1` update.
 
 We update `on-init` to remove our Eyre call, since new installs shouldn't connect at all now.
 
 Let's commit and see the result of recompiling:
+
 ```
 > |commit %home
 >=
@@ -506,23 +558,28 @@ Let's commit and see the result of recompiling:
 > :lifecycle +dbug
 [%2 val=100 msg='my message']
 ```
+
 You can play around and change some of the print messages to force recompilation. However, the state will remain the same, because when we're in state `%2`, it sismply sets the current state to the previous (i.e no change).
 
 ## Gall-Managed App State: the `bowl`
+
 In addition to any state that we put inside our agent, we also have access to some state that Gall keeps track of and injects whenever it calls an arm in our agent. That state is of type `bowl:gall`.
 
 Near the top of our `lifecycle.hoon` file, we have:
+
 ```
 ^-  agent:gall
 |_  =bowl:gall
 +*  this      .
     default   ~(. (default-agent this %|) bowl)
 ```
-The key here is `|_  =bowl:gall`, which says that our agent is a door that takes a parameter of type `bowl:gall` called `bowl`. We also pass that to `default-agent` when we initialize that core, and if you use a helper core, you'd pass it also (we'll see this is in later lessons).
 
-You can find the type definition of `bowl` in `/sys/zuze.hoon` if you search for `++  bowl`. For now, just know that it contains our ship name, the name of the ship that made the current call to us, the name of our agent, the current time, entropy, and data about any subscriptions our agent has made from or to it.
+The key here is `|_ =bowl:gall`, which says that our agent is a door that takes a parameter of type `bowl:gall` called `bowl`. We also pass that to `default-agent` when we initialize that core, and if you use a helper core, you'd pass it also (we'll see this is in later lessons).
+
+You can find the type definition of `bowl` in `/sys/zuze.hoon` if you search for `++ bowl`. For now, just know that it contains our ship name, the name of the ship that made the current call to us, the name of our agent, the current time, entropy, and data about any subscriptions our agent has made from or to it.
 
 We can print `bowl` for this app by entering at the Dojo:
+
 ```
 > :lifecycle +dbug %bowl
 
@@ -540,14 +597,17 @@ We can print `bowl` for this app by entering at the Dojo:
 ```
 
 ## A Note on `on-save`
+
 `on-save` is mostly used by Gall itself to transition between state versions. However, it's also used by `dbug` to get the current state of the app wrapped by `dbug`. This is possible because `dbug` takes an `agent:gall` itself as an argument, so it has access to calling all of that `agent`'s arms.
 
 ## Summary: Full Gall Compilation Lifecycle
+
 We're now ready to explicitly state Gall's compiliation lifecycle.
+
 1. Register an app.
 2. Compile it every time its code changes.
 3. Run `on-init` the first time it compiles successfully, and never again after that.
-4. For all other successful compilations, call the *previous* version of `on-save` and pass its output to the *current* version of `on-load`.
+4. For all other successful compilations, call the _previous_ version of `on-save` and pass its output to the _current_ version of `on-load`.
 
 Remember, the point of `on-init` is to get fresh installs of your app into the correct state with the correct cards passed out.
 
@@ -560,20 +620,26 @@ If you want to iterate until you get your `on-init` right, I recommend using the
 ## Exercises
 
 ### Code Reading
-1. Find 2 Gall agents in `app` that return cards as part of their `on-load`. 
-  - Explain what you think the cards are doing
-  - Is the action the cards are doing repeated in `on-init`? Why or why not? (The answer could vary from program to program).
+
+1. Find 2 Gall agents in `app` that return cards as part of their `on-load`.
+
+- Explain what you think the cards are doing
+- Is the action the cards are doing repeated in `on-init`? Why or why not? (The answer could vary from program to program).
+
 2. Refer to this version of [file-server.hoon](https://github.com/urbit/urbit/commit/0d1930b6ac4d2b001a973089f3999758ee09d7d0)
-  - Where are its `versioned-state` and `state-0` defined? 
-  - What is the advantage of this approach?
-  - What does the new version of the state (`state-1`) enable that `state-0` did not? (The transition in `on-load` gives some hints here)
+
+- Where are its `versioned-state` and `state-0` defined?
+- What is the advantage of this approach?
+- What does the new version of the state (`state-1`) enable that `state-0` did not? (The transition in `on-load` gives some hints here)
 
 ### Code Modification
-* Modify `app/chat-store.hoon` in a fake ship to have a new state, `state-4`. This state should include the `inbox` from the prior state, but add a `(set ship)` with face `bad-people`.
-* Get it to work in `on-load`, and initialize `bad-people` to contain the ship `~timluc-miptev`.
-* Update `on-init` to have `~timluc-miptev` in its initial `bad-people` if the app is installed from scratch.
+
+- Modify `app/chat-store.hoon` in a fake ship to have a new state, `state-4`. This state should include the `inbox` from the prior state, but add a `(set ship)` with face `bad-people`.
+- Get it to work in `on-load`, and initialize `bad-people` to contain the ship `~timluc-miptev`.
+- Update `on-init` to have `~timluc-miptev` in its initial `bad-people` if the app is installed from scratch.
 
 ### `chat-admin` Planning
+
 List the types of cards that you think your chat admin app will need to pass in its `on-init`, either to Arvo or other agents. You should refer to your feature list from the prior lesson's exercises.
 
 [Prev: The 10 Arms of Gaal: App Structure](arms.md) | [Home](overview.md) | [Next: Importing Code and Static Resources](ford.md)


### PR DESCRIPTION
Added a couple short paragraphs introducing `|fade` to keep the current lesson structure of having the first compile fail (while avoiding the gall compile bug). Though it's kind of a make-shift solution, it introduces a command so it has educational value anyways so I think it merits it.

And deleted trailing whitespaces.